### PR TITLE
Specify the Request property where the locale will be attached with the requestProperty option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Type: `Array` Default value `undefined`
 
 Lookup results are validated against this list of allowed locales if provided.
 
+#### Request property
+Type: `String` Default value `'locale'`
+
+By default, the locale is attached to `req.locale` but can be configured with the `requestProperty` option.
 
 ## Custom lookups
 Add custom lookups or overwrite the default ones by using the `lookups` property:
@@ -108,4 +112,7 @@ let localeMiddleware = createLocaleMiddleware({
     custom: (req) => req.ip === '127.0.0.1' ? 'en_US' : undefined;
   }
 });
+
+
+
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,8 @@ function isLanguageOrLocale (locale) {
 
 function createLocaleMiddleware (options = {}) {
   options = Object.assign({
-    priority: ['accept-language', 'default']
+    priority: ['accept-language', 'default'],
+    requestProperty: 'locale'
   }, options);
 
   let lookups = Object.assign(
@@ -124,7 +125,7 @@ function createLocaleMiddleware (options = {}) {
       }
     }
 
-    req.locale = result;
+    req[options.requestProperty] = result;
 
     next();
   };

--- a/test/index.js
+++ b/test/index.js
@@ -20,13 +20,22 @@ describe('()', () => {
     assert.strictEqual(type, 'function');
   });
 
-  it('should extend the request object', () => {
+  it('should extend the request object adding the default requestProperty', () => {
     let localeMiddleware = createLocaleMiddleware();
 
     let req = {};
     localeMiddleware(req, {}, () => {});
     assert('locale' in req);
     assert.notStrictEqual(req.locale, undefined);
+  });
+
+  it('should extend the request object adding the custom requestProperty', () => {
+    let localeMiddleware = createLocaleMiddleware({ requestProperty: 'custom-locale' });
+
+    let req = {};
+    localeMiddleware(req, {}, () => {});
+    assert('custom-locale' in req);
+    assert.notStrictEqual(req['custom-locale'], undefined);
   });
 });
 


### PR DESCRIPTION
# Overview
Adding the `requestProperty` option to configure the Request's property where the locale will be attached.

### Request property
Type: `String` Default value `'locale'`

By default, the locale is attached to `req.locale` but can be configured with the `requestProperty` option.