### PR TITLE
Locale should be returned if locale is default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ function createLocaleMiddleware (options = {}) {
   }
 
   function isAllowed (locale) {
-    return !options.allowed || options.allowed.indexOf(locale) >= 0;
+    return !options.allowed || options.allowed.indexOf(locale) >= 0 || ( options.default && options.default === locale );
   }
 
   function * lookup (req, all) {

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ function createLocaleMiddleware (options = {}) {
   }
 
   function isAllowed (locale) {
-    return !options.allowed || options.allowed.indexOf(locale) >= 0 || ( options.default && options.default === locale );
+    return !options.allowed || options.allowed.indexOf(locale) >= 0 || (options.default && options.default === locale);
   }
 
   function * lookup (req, all) {

--- a/test/index.js
+++ b/test/index.js
@@ -141,6 +141,20 @@ const runTests = (expressVersion) => {
         }, done);
     });
 
+    it('should return default even when default is not in allowed', done => {
+      request(createServer(expressVersion, {
+        default: 'de_DE',
+        allowed: ['de_AT', 'de_CH']
+      }))
+        .get('/')
+        .set('Accept-Language', 'en,en-GB;q=0.8')
+        .expect({
+          source: 'default',
+          language: 'de',
+          region: 'DE'
+        }, done);
+    });
+
     it('should map a language to a default', done => {
       request(createServer(expressVersion, {
         priority: 'cookie,map',


### PR DESCRIPTION
Possible fix for issue #15 , where locale was undefined in case the default value was not part of the allowed array. Now it does also check if locale is default value if default is set.

Use case that is not covered by this pull request is when default value is not set (so should default to 'en_GB' as per default.js) and missing from allowed.