### PR TITLE
Support priority using any case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 node_modules
 npm-debug.log

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ function createLocaleMiddleware (options = {}) {
       .forEach(([name, { uses = [] }]) => {
         uses.filter(locale => !isAllowed(locale))
           .forEach(locale => {
-            throw new Error(`Invalid configration (locale '${locale}' in lookup '${name}' should be whitelisted)`);
+            throw new Error(`Invalid configuration (locale '${locale}' in lookup '${name}' should be whitelisted)`);
           });
       });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -39,13 +39,11 @@ function createLocaleMiddleware (options = {}) {
   if (typeof options.priority === 'string') {
     options.priority = options.priority.split(/ *, */g);
   }
+  options.priority = options.priority.map(name => name.toLowerCase());
 
   options.lookups = options.lookups || {};
 
-  const isDefined = name => {
-    name = name.toLowerCase();
-    return (name in LOOKUP_CREATORS) || (name in options.lookups);
-  };
+  const isDefined = name => (name in LOOKUP_CREATORS) || (name in options.lookups);
 
   if (!options.priority.every(isDefined)) {
     const notFound = options.priority.find(name => !isDefined(name));
@@ -54,15 +52,12 @@ function createLocaleMiddleware (options = {}) {
   }
 
   const lookups = new Map(options.priority.map(
-    name => {
-      name = name.toLowerCase();
-      return [
-        name,
-        name in options.lookups
-          ? options.lookups[name]
-          : LOOKUP_CREATORS[name](options[name])
-      ];
-    }
+    name => [
+      name,
+      name in options.lookups
+        ? options.lookups[name]
+        : LOOKUP_CREATORS[name](options[name])
+    ]
   ));
 
   const isAllowed = locale => !options.allowed || options.allowed.indexOf(locale) >= 0;
@@ -79,8 +74,7 @@ function createLocaleMiddleware (options = {}) {
   }
 
   function * lookup (req, all) {
-    for (let source of options.priority) {
-      source = source.toLowerCase();
+    for (const source of options.priority) {
       let locales = lookups.get(source)(req, all);
 
       if (typeof locales === 'string') {

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,10 @@ function createLocaleMiddleware (options = {}) {
 
   options.lookups = options.lookups || {};
 
-  const isDefined = name => (name.toLowerCase() in LOOKUP_CREATORS) || (name in options.lookups);
+  const isDefined = name => {
+    name = name.toLowerCase();
+    return (name in LOOKUP_CREATORS) || (name in options.lookups);
+  };
 
   if (!options.priority.every(isDefined)) {
     const notFound = options.priority.find(name => !isDefined(name));
@@ -51,12 +54,15 @@ function createLocaleMiddleware (options = {}) {
   }
 
   const lookups = new Map(options.priority.map(
-    name => [
-      name,
-      name in options.lookups
-        ? options.lookups[name]
-        : LOOKUP_CREATORS[name](options[name])
-    ]
+    name => {
+      name = name.toLowerCase();
+      return [
+        name,
+        name in options.lookups
+          ? options.lookups[name]
+          : LOOKUP_CREATORS[name](options[name])
+      ];
+    }
   ));
 
   const isAllowed = locale => !options.allowed || options.allowed.indexOf(locale) >= 0;
@@ -73,7 +79,8 @@ function createLocaleMiddleware (options = {}) {
   }
 
   function * lookup (req, all) {
-    for (const source of options.priority) {
+    for (let source of options.priority) {
+      source = source.toLowerCase();
       let locales = lookups.get(source)(req, all);
 
       if (typeof locales === 'string') {

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ function createLocaleMiddleware (options = {}) {
 
   options.lookups = options.lookups || {};
 
-  const isDefined = name => (name in LOOKUP_CREATORS) || (name in options.lookups);
+  const isDefined = name => (name.toLowerCase() in LOOKUP_CREATORS) || (name in options.lookups);
 
   if (!options.priority.every(isDefined)) {
     const notFound = options.priority.find(name => !isDefined(name));

--- a/test/index.js
+++ b/test/index.js
@@ -75,7 +75,7 @@ describe('()', () => {
       });
     }
 
-    assert.throws(createInvalidConfig, new Error('Invalid configration (locale \'en-GB\' in lookup \'default\' should be whitelisted)'));
+    assert.throws(createInvalidConfig, new Error('Invalid configuration (locale \'en-GB\' in lookup \'default\' should be whitelisted)'));
   });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -53,15 +53,6 @@ describe('()', () => {
     assert.strictEqual(req.locale.source, 'custom');
   });
 
-  it('should support priority using any case', () => {
-    const localeMiddleware = createLocaleMiddleware({ priority: 'AcCePt-LanGuaGe' });
-
-    const req = {};
-    localeMiddleware(req, {}, () => {});
-    assert('locale' in req);
-    assert.strictEqual(req.locale, undefined);
-  });
-
   it('should check existence of custom lookup methods', () => {
     function createUndefinedLookup () {
       createLocaleMiddleware({
@@ -115,6 +106,20 @@ describe('with Express', () => {
         source: 'accept-language',
         language: 'de',
         region: 'CH'
+      })
+      .end(done);
+  });
+
+  it('should parse accept-language header (setting priority in any case)', done => {
+    request(createServer({
+      priority: 'Accept-Language'
+    }))
+      .get('/')
+      .set('Accept-Language', 'es-MX;q=0.8,en-GB;q=0.6')
+      .expect({
+        source: 'accept-language',
+        language: 'es',
+        region: 'MX'
       })
       .end(done);
   });

--- a/test/index.js
+++ b/test/index.js
@@ -110,6 +110,20 @@ describe('with Express', () => {
       .end(done);
   });
 
+  it('should parse accept-language header (setting priority using any case)', done => {
+    request(createServer({
+      priority: 'Accept-Language'
+    }))
+      .get('/')
+      .set('Accept-Language', 'de-CH;q=0.8,en-GB;q=0.6')
+      .expect({
+        source: 'accept-language',
+        language: 'de',
+        region: 'CH'
+      })
+      .end(done);
+  });
+
   it('should read cookie', done => {
     request(createServer({
       cookie: { name: 'lang' },

--- a/test/index.js
+++ b/test/index.js
@@ -53,6 +53,15 @@ describe('()', () => {
     assert.strictEqual(req.locale.source, 'custom');
   });
 
+  it('should support priority using any case', () => {
+    const localeMiddleware = createLocaleMiddleware({ priority: 'AcCePt-LanGuaGe' });
+
+    const req = {};
+    localeMiddleware(req, {}, () => {});
+    assert('locale' in req);
+    assert.strictEqual(req.locale, undefined);
+  });
+
   it('should check existence of custom lookup methods', () => {
     function createUndefinedLookup () {
       createLocaleMiddleware({
@@ -99,20 +108,6 @@ describe('with Express', () => {
   it('should parse accept-language header', done => {
     request(createServer({
       priority: 'accept-language'
-    }))
-      .get('/')
-      .set('Accept-Language', 'de-CH;q=0.8,en-GB;q=0.6')
-      .expect({
-        source: 'accept-language',
-        language: 'de',
-        region: 'CH'
-      })
-      .end(done);
-  });
-
-  it('should parse accept-language header (setting priority using any case)', done => {
-    request(createServer({
-      priority: 'Accept-Language'
     }))
       .get('/')
       .set('Accept-Language', 'de-CH;q=0.8,en-GB;q=0.6')


### PR DESCRIPTION
Make possible to use any case for the `priority` option.

Before changes in this PR, an error was thrown when a consumer of the `express-locale` middleware sets `priority` option like this: `'Accept-Language'`