### PR TITLE
docs: add note about including map

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Type: `Object` Default value `{}`
 
 Maps lookup results that return only a language to a full locale.
 
+**Note:** Ensure that you include the `map` property in the array key `priority` to prioritize language mapping in the lookup process.
+
 #### default
 Type: `String` Default value `'en-GB'`
 


### PR DESCRIPTION
Add a note to manually specify `map` in `priority`, since if a `map` object is defined, it doesn't happen automatically. 